### PR TITLE
Add support for Bulk Queries

### DIFF
--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -1,0 +1,88 @@
+package com.springml.spark.salesforce
+
+import java.text.SimpleDateFormat
+
+import com.springml.salesforce.wave.api.BulkAPI
+import org.apache.log4j.Logger
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SQLContext}
+import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import com.springml.salesforce.wave.model.{BatchInfo, BatchInfoList, JobInfo}
+import org.apache.http.Header
+import org.apache.spark.rdd.RDD
+
+import scala.collection.JavaConverters._
+
+/**
+  * Relation class for reading data from Salesforce and construct RDD
+  */
+case class BulkRelation(
+    query: String,
+    sfObject: String,
+    bulkAPI: BulkAPI,
+    contentType: String,
+    customHeaders: List[Header],
+    userSchema: StructType,
+    sqlContext: SQLContext,
+    inferSchema: Boolean) extends BaseRelation with TableScan {
+
+  import sqlContext.sparkSession.implicits._
+
+  private val logger = Logger.getLogger(classOf[BulkRelation])
+
+  def buildScan() = records.rdd
+
+  override def schema: StructType = {
+    if (userSchema != null) {
+      userSchema
+    } else {
+      records.schema
+    }
+
+  }
+
+  lazy val records: DataFrame = {
+    val inputJobInfo = new JobInfo(contentType, sfObject, "query")
+    val jobInfo = bulkAPI.createJob(inputJobInfo, customHeaders.asJava)
+    val jobId = jobInfo.getId
+
+    val batchInfo = bulkAPI.addBatch(jobId, query)
+
+    if (awaitJobCompleted(jobId)) {
+      val batchInfoList = bulkAPI.getBatchInfoList(jobId)
+      val batchInfos = batchInfoList.getBatchInfo().asScala.toList
+      val completedBatchInfos = batchInfos.filter(batchInfo => batchInfo.getState().equals("Completed"))
+
+      val csvData = sqlContext.sparkContext.parallelize(
+        completedBatchInfos.flatMap(batchInfo => {
+          val resultIds = bulkAPI.getBatchResultIds(jobId, batchInfo.getId)
+
+          val result = bulkAPI.getBatchResult(jobId, batchInfo.getId, resultIds.get(resultIds.size() - 1))
+
+          result.lines.toList
+        })
+      ).toDS()
+
+      sqlContext.sparkSession.read.option("header", true).option("inferSchema",true).csv(csvData)
+    } else {
+      throw new Exception("Job completion timeout")
+    }
+  }
+
+  private def awaitJobCompleted(jobId: String): Boolean = {
+    var i = 1
+    // Maximum wait time is 10 mins for a job
+    while (i < 3000) {
+      if (bulkAPI.isCompleted(jobId)) {
+        logger.info("Job completed")
+        return true
+      }
+
+      logger.info("Job not completed, waiting...")
+      Thread.sleep(200)
+      i = i + 1
+    }
+
+    return false
+  }
+}

--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -63,7 +63,7 @@ case class BulkRelation(
         })
       ).toDS()
 
-      sqlContext.sparkSession.read.option("header", true).option("inferSchema",true).csv(csvData)
+      sqlContext.sparkSession.read.option("header", true).option("inferSchema", inferSchema).csv(csvData)
     } else {
       throw new Exception("Job completion timeout")
     }

--- a/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
@@ -131,13 +131,13 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
           sqlContext,
           inferSchemaFlag
         )
-      }
-
-      val forceAPI = APIFactory.getInstance.forceAPI(username, password, login,
+      } else {
+        val forceAPI = APIFactory.getInstance.forceAPI(username, password, login,
           version, Integer.getInteger(pageSize), Integer.getInteger(maxRetry))
-      DatasetRelation(null, forceAPI, soql.get, schema, sqlContext,
+        DatasetRelation(null, forceAPI, soql.get, schema, sqlContext,
           null, 0, sampleSize.toInt, encodeFields, inferSchemaFlag,
           replaceDatasetNameWithId.toBoolean, sdf(dateFormat))
+      }
     }
 
   }

--- a/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
@@ -18,10 +18,14 @@ package com.springml.spark.salesforce
 import java.text.SimpleDateFormat
 
 import com.springml.salesforce.wave.api.APIFactory
+import org.apache.http.Header
+import org.apache.http.message.BasicHeader
 import org.apache.log4j.Logger
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, SchemaRelationProvider}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
+
+import scala.collection.mutable.ListBuffer
 
 /**
  * Default source for Salesforce wave data source.
@@ -67,6 +71,9 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     val encodeFields = parameters.get("encodeFields")
     val replaceDatasetNameWithId = parameters.getOrElse("replaceDatasetNameWithId", "false")
 
+    val bulkStr = parameters.getOrElse("bulk", "false")
+    val bulkFlag = flag(bulkStr, "bulk")
+
     validateMutualExclusive(saql, soql, "saql", "soql")
     val inferSchemaFlag = flag(inferSchema, "inferSchema")
 
@@ -78,6 +85,52 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     } else {
       if (replaceDatasetNameWithId.toBoolean) {
         logger.warn("Ignoring 'replaceDatasetNameWithId' option as it is not applicable to soql")
+      }
+
+      if (soql.isEmpty) {
+        throw new Exception("soql must not be empty")
+      }
+
+      if (bulkFlag) {
+        val bulkApi = APIFactory.getInstance.bulkAPI(username, password, login, version)
+
+        val sfObject = parameters.get("sfObject")
+        if (sfObject.isEmpty) {
+          throw new Exception("sfObject must not be empty when performing bulk query")
+        }
+
+        val contentType = parameters.getOrElse("contentType", "CSV")
+
+        var customHeaders = ListBuffer[Header]()
+        val pkChunkingStr = parameters.getOrElse("pkChunking", "false")
+        val pkChunking = flag(pkChunkingStr, "pkChunkingStr")
+
+        if (pkChunking) {
+          val chunkSize = parameters.get("chunkSize")
+
+          if (!chunkSize.isEmpty) {
+            try {
+              chunkSize.get.toInt
+            }
+            catch {
+              case e: Exception => throw new Exception("chunkSize must be a valid integer")
+            }
+            customHeaders += new BasicHeader("Sforce-Enable-PKChunking", s"chunkSize=$chunkSize")
+          } else {
+            customHeaders += new BasicHeader("Sforce-Enable-PKChunking", "true")
+          }
+        }
+
+        BulkRelation(
+          soql.get,
+          sfObject.get,
+          bulkApi,
+          contentType,
+          customHeaders.toList,
+          schema,
+          sqlContext,
+          inferSchemaFlag
+        )
       }
 
       val forceAPI = APIFactory.getInstance.forceAPI(username, password, login,

--- a/src/test/scala/com/springml/spark/salesforce/TestBulkRelation.scala
+++ b/src/test/scala/com/springml/spark/salesforce/TestBulkRelation.scala
@@ -1,0 +1,103 @@
+package com.springml.spark.salesforce
+
+import com.springml.salesforce.wave.api.BulkAPI
+import com.springml.salesforce.wave.model.{BatchInfo, BatchInfoList, JobInfo}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+import org.scalatest.mock.MockitoSugar
+import java.util.ArrayList
+
+import org.apache.http.Header
+import org.apache.http.message.BasicHeader
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.types.StructType;
+
+class TestBulkRelation extends FunSuite with MockitoSugar with BeforeAndAfterEach {
+  val bulkAPI = mock[BulkAPI]
+
+  val jobInfo = mock[JobInfo]
+
+  val batchInfo1 = mock[BatchInfo]
+  val batchInfo2 = mock[BatchInfo]
+  val batchInfo3 = mock[BatchInfo]
+
+  val batchInfoList = mock[BatchInfoList]
+  val batchInfos = new ArrayList[BatchInfo](){ { batchInfo1, batchInfo2, batchInfo3 } }
+
+  val jobId = "12345678"
+  val batchInfoId1 = "87654321"
+  val batchInfoId2 = "97654321"
+  val batchInfoId3 = "97654320"
+
+  val batchInfoStatus1 = "Completed"
+  val batchInfoStatus2 = "Completed"
+  val batchInfoStatus3 = "Not Processed"
+
+  val batchResultIds1 = new ArrayList[String]() { { "1", "4" } }
+  val batchResultIds2 = new ArrayList[String]() { { "2" } }
+
+  val batchResult1 = "Id,Name\n123,Name1\n124,Name2\n"
+  val batchResult2 = "Id,Name\n125,Name3\n"
+
+  val sfObject = "TestObject"
+  val soql = "SELECT Id, Name FROM TestObject"
+  val contentType = "CSV"
+  val customHeaders = List(new BasicHeader("Sforce-Enable-PKChunking", "true"))
+
+
+  var sparkConf: SparkConf = _
+  var sc: SparkContext = _
+  var sqlContext: SQLContext = _
+
+  override def beforeEach() {
+    when(jobInfo.getId()).thenReturn(jobId)
+
+
+    when(bulkAPI.createJob(any(), any())).thenReturn()
+    when(bulkAPI.addBatch(jobId, soql)).thenReturn(batchInfo3)
+    when(bulkAPI.getBatchInfoList(jobId)).thenReturn(batchInfoList)
+    when(batchInfoList.getBatchInfo).thenReturn(batchInfos)
+
+    when(batchInfo1.getId()).thenReturn(batchInfoId1)
+    when(batchInfo1.getState()).thenReturn(batchInfoStatus1)
+
+    when(batchInfo2.getId()).thenReturn(batchInfoId2)
+    when(batchInfo2.getState()).thenReturn(batchInfoStatus2)
+
+    when(batchInfo3.getId()).thenReturn(batchInfoId3)
+    when(batchInfo3.getState()).thenReturn(batchInfoStatus3)
+
+    when(bulkAPI.getBatchResultIds(jobId, batchInfoId1)).thenReturn(batchResultIds1)
+    when(bulkAPI.getBatchResultIds(jobId, batchInfoId2)).thenReturn(batchResultIds2)
+
+    when(bulkAPI.getBatchResult(jobId, batchInfoId1, batchResultIds1.get(batchResultIds1.size() - 1))).thenReturn(batchResult1)
+    when(bulkAPI.getBatchResult(jobId, batchInfoId1, batchResultIds2.get(batchResultIds2.size() - 1))).thenReturn(batchResult2)
+
+    sparkConf = new SparkConf().setMaster("local").setAppName("Test Bulk Relation")
+    sc = new SparkContext(sparkConf)
+    sqlContext = new SQLContext(sc)
+  }
+
+  override def afterEach() {
+    sc.stop()
+  }
+
+  test("Regular case") {
+    val bulkRelation = new BulkRelation(
+      soql,
+      sfObject,
+      bulkAPI,
+      contentType,
+      customHeaders,
+      null,
+      sqlContext,
+      true
+    )
+
+    bulkRelation.records.cache()
+
+    assert(bulkRelation.records.count() == 3)
+  }
+}


### PR DESCRIPTION
Reference: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_using_bulk_query.htm

Add support to perform bulk queries with an option to include "PK Chunking". This will create a background job on Salesforce to perform a SOQL query. Upon polling for the completion of the job, the results are fetched and combined.

Currently blocked until PRs `springml/salesforce-wave-api` is merged.